### PR TITLE
Run simnibs segmentation code also supports SLURM

### DIFF
--- a/configs/tutorial_config.yaml
+++ b/configs/tutorial_config.yaml
@@ -4,6 +4,13 @@ simnibs_bin_path: /home/.../SimNIBS-4.0/bin/ # change to simnibs install
 t1_path_template: sub-001_T1.nii.gz # path to T1 relative to data_path; all string substitutions will be done using subject_id
 t2_path_template: sub-001_T2.nii.gz # path to T2 relative to data_path; all string substitutions will be done using subject_id
 
+# An optional path to LD_LIBRARY used during SimNIBS installation
+# If you experience an `undefined symbol` error in `create_mesh_surf.cpython-39-x86_64-linux-gnu.so`, set the next line to your LD_LIBRARY location
+#ld_library_path: /opt/gcc/7.2.0/lib64  % or for slurm /home/.../SimNIBS-4.0/simnibs_env/lib/python3.9/site-packages/simnibs/mesh_tools/cgal/../../external/lib/linux
+
+# If you encounter the error "The qform and sform of do not match. Please run charm with the --forceqform option" when running charm, you can set this to 1 to do it for all subjects
+use_forceqform: 0
+
 transducer: 
   n_elements: 10 # number of elements in the transducer
   Elements_ID_mm: [10, 22.3, 30, 36.3, 41.7, 46.5, 51, 55.1, 58.9, 62.5]
@@ -12,7 +19,6 @@ transducer:
   dist_to_plane_mm: 67.5 # distance to the transducer plane from the geometric focus
   source_amp: 183573 # [Pa]
   source_phase_deg: [0, 360, 17, 39, 43, 29, 68, 23, 150, 26] # source phase [deg]
-  pos_t1_grid: [210, 184, 117]
   source_freq_hz: 500e3 # [Hz] the central frequency | NOTE: This needs to correspond to the alpha0 in the medium setup
   pos_t1_grid: [128, 139, 15] # position on T1 grid 
 

--- a/functions/single_subject_pipeline_with_qsub.m
+++ b/functions/single_subject_pipeline_with_qsub.m
@@ -5,6 +5,10 @@ function single_subject_pipeline_with_qsub(subject_id, parameters, timelimit, me
         timelimit (1,1) double = 60*60*4 % time limit for a job in seconds (4 hours by default)
         memorylimit (1,1) double = 40 % memory limit for a job in Gb (40 Gb by default)
     end
+
+    % Save that this parameter set is using qsub for further branching
+    parameters.submit_medium = 'qsub';
+
     if parameters.interactive
         warning('Processing is set to interactive mode, this is not supported when running jobs with qsub, switching off interactive mode.')
         parameters.interactive = 0;

--- a/functions/single_subject_pipeline_with_slurm.m
+++ b/functions/single_subject_pipeline_with_slurm.m
@@ -5,6 +5,10 @@ function single_subject_pipeline_with_slurm(subject_id, parameters, timelimit, m
         timelimit string = "04:00:00" % time limit for a job in seconds (4 hours by default)
         memorylimit (1,1) double = 40 % memory limit for a job in Gb (40 Gb by default)
     end
+
+    % Save that this parameter set is using slurm for further branching
+    parameters.submit_medium = 'slurm';
+
     if parameters.interactive
         warning('Processing is set to interactive mode, this is not supported when running jobs with qsub, switching off interactive mode.')
         parameters.interactive = 0;


### PR DESCRIPTION
When running the whole pipeline with SLURM, an error occured due to run_segmentation not supporting a SLURM command. Therefore, this feature is added. Besides, the tutorial config has been adapted in the following way:
- pos_T1_grid had a duplicate 
- LD_LIBRARY_PATH and use_forceqform were missing